### PR TITLE
Add node review primer

### DIFF
--- a/src/pages/review-primers/node.md
+++ b/src/pages/review-primers/node.md
@@ -3,3 +3,43 @@ title: Node Review Primer
 description: Prepare for reviewing node Internet Computer Protocol replica upgrades
 layout: ../../layout/BaseLayout.astro
 ---
+
+## Scope
+
+- Node lifecycle
+- Configuration management
+- IC OS (Guest)
+- HostOS (Host)
+- Testnet Deployment
+
+### Summary
+
+- IC-OS is an all-encompassing term for all the operating systems within the IC—hostOS, guestOS, SetupOS, and boundary-guestOS
+- SetupOS is an image containing both the HostOS and GuestOS
+    - Deploys and bootstraps HostOS
+- HostOS is the operating system that runs on the host machine
+  - Main responsibility is to launch and run the GuestOS in a virtual machine
+  - Creates a contained running environment across different hardware for the GuestOS
+  - Acts as a convenience wrapper for Node Providers
+  - Enables a secure enclave for guestOS (via SEV-SNP)
+- GuestOS runs inside a virtual machine on the hostOS.
+  - Runs the core IC protocol is run (the replica and orchestrator)
+  - Protected in a secure enclave such that if an attacker gained access, they could not view or modify the data
+  - Secure enclave is only possible in a virtual machine
+  - Secure enclave is a work in progress
+
+### Resources
+
+- IC OS
+  - [IC OS Readme](https://github.com/dfinity/ic/tree/master/ic-os#readme)
+  - [SetupOS Readme](https://github.com/dfinity/ic/tree/master/ic-os/setupos)
+  - [HostOS Readme](https://github.com/dfinity/ic/tree/master/ic-os/hostos)
+  - [GuestOS Readme](https://github.com/dfinity/ic/tree/master/ic-os/guestos)
+- [Node Provider Onboarding](https://wiki.internetcomputer.org/wiki/Node_Provider_Onboarding)
+
+### Codebase
+
+- [IC OS Disk Images](https://github.com/dfinity/ic/tree/master/ic-os) (except `boundary-os` and `boundary-api-os`)
+- [GuestOS Vsock Agent](https://github.com/dfinity/ic/tree/master/rs/guestos_vsock_agent)
+- [IC OS Rust Crates](https://github.com/dfinity/ic/tree/master/rs/ic_os)
+- [Registry (NNS) Node Helper](https://github.com/dfinity/ic/blob/master/rs/registry/helpers/src/node.rs)

--- a/src/pages/review-primers/overview.md
+++ b/src/pages/review-primers/overview.md
@@ -21,11 +21,12 @@ Review primers are onboarding documents that aim to arm CodeGov code reviewers w
 
 ## Resources
 
-There are already many great resources that you can use
+There are already many great resources that you can use to learn about the Internet Computer overall before diving deeper into one of the lower level layers.
 
 - [Internetcomputer.org](https://internetcomputer.org/)
-- [Wiki.internetcomputer.org](https://wiki.internetcomputer.org/)
+- [wiki.internetcomputer.org](https://wiki.internetcomputer.org/)
 - [Internet Computer Whitepaper](https://internetcomputer.org/whitepaper.pdf)
+- [Internet Computer Interface Spec](https://github.com/dfinity/interface-spec/blob/master/spec/index.adoc)
 - [Dfinity YouTube channel](https://www.youtube.com/@DFINITY/featured)
 - [Inside the Internet Computer - YouTube Playlist](https://www.youtube.com/playlist?list=PLuhDt1vhGcrfHG_rnRKsqZO1jL_Pd970h)
 - [Git Codeowners](https://github.com/dfinity/ic/blob/master/.gitlab/CODEOWNERS): The Codeowners configuration assigns “ownership” of Dfinity teams to certain parts of the codebase. Since the team structure aligns with components of the stack and review categories, this is a useful resource for identifying which parts of the codebase are relevant for each category.
@@ -40,6 +41,8 @@ Several technologies are used throughout many layers of the Internet Computer Pr
 
 - [The Rust Book](https://doc.rust-lang.org/book/)
 - [Rust by Example](https://doc.rust-lang.org/rust-by-example/)
+- [The Easy Rust Book](https://dhghomon.github.io/easy_rust/)
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
 - [Mmapped: Designing error types in Rust](https://mmapped.blog/posts/12-rust-error-handling.html)
 
 ### Tokio


### PR DESCRIPTION
This PR adds the review primer for the "Node" category.

There's unfortunately a lot less public resources available for this category, but thankfully this team has great documentation available within the IC's codebase.

They also own much more self-contained areas of the codebase and their code is really well co-located.