### PR TITLE
Add crypto review primer

### DIFF
--- a/src/pages/review-primers/consensus.md
+++ b/src/pages/review-primers/consensus.md
@@ -4,7 +4,7 @@ description: Prepare for reviewing consensus layer Internet Computer Protocol re
 layout: ../../layout/BaseLayout.astro
 ---
 
-### Scope
+## Scope
 
 - Consensus crate
 - Artifact pool
@@ -17,13 +17,13 @@ layout: ../../layout/BaseLayout.astro
 - Subnet backup
 - Subnet splitting
 
-### Summary
+## Summary
 
 - The consensus layer receives unordered messages from the P2P layer.
 - Consensus achieves agreement as to which messages and in which order the IC should execute.
 - It can do this as long as more than ⅔ of the nodes are honest and functioning well.
 
-### Resources
+## Resources
 
 - Consensus
   - [YouTube: Inside the Internet Computer | Consensus Overview](https://www.youtube.com/watch?v=vVLRRYh3JYo)
@@ -43,7 +43,7 @@ layout: ../../layout/BaseLayout.astro
   - [NIDKG Whitepaper](https://eprint.iacr.org/2021/339.pdf)
 - [GitHub: Orchestrator Docs](https://github.com/dfinity/ic/tree/master/rs/orchestrator)
 
-### Codebase
+## Codebase
 
 - Testnet
   - [NNS State Deployment](https://github.com/dfinity/ic/blob/master/testnet/tools/nns_state_deployment.sh)

--- a/src/pages/review-primers/crypto.md
+++ b/src/pages/review-primers/crypto.md
@@ -3,3 +3,57 @@ title: Crypto Review Primer
 description: Prepare for reviewing crypto Internet Computer Protocol replica upgrades
 layout: ../../layout/BaseLayout.astro
 ---
+
+## Scope
+
+- Crypto component
+- Reusable crypto libraries
+
+## Summary
+- The crypto component:
+  - Provides consistent APIs for cryptographic functions
+  - Used by other components of the replica's stack
+  - Provides secure storage and generation of secret keys
+- The crypto component consists of two main pieces:
+  - External API: Identifier to Key Mapping (IDKM)
+    - Stores node public keys
+    - Stores threshold signature public keys
+    - Called using node identifiers
+    - Maps node identifiers to the appropriate keys and algorithms
+    - Fetches public keys of other nodes from the Registry canister on the NNS subnet
+  - Internal API: Crypto Service Provider (CSP)
+    - Generates and stores secret keys
+    - Called using node identifiers and secret key IDs
+    - Performs cryptographic operations
+
+## Resources
+
+- Chain Key Cryptography
+  - [YouTube: Inside the Internet Computer | Chain Key Cryptography](https://www.youtube.com/watch?v=vUcDRFC09J0)
+  - [Internet Computer: Chain Key Cryptography](https://internetcomputer.org/how-it-works/chain-key-technology)
+  - [Medium: Chain Key Cryptography](https://medium.com/dfinity/chain-key-technology-one-public-key-for-the-internet-computer-6a3644901e28)
+- Non-Interactive Distributed Key Generation (NIDKG)
+  - [YouTube: Inside the Internet Computer | NIDKG](https://www.youtube.com/watch?v=gKUi-2T7tdc)
+  - [Medium: NIDKG](https://medium.com/dfinity/applied-crypto-one-public-key-for-the-internet-computer-ni-dkg-4af800db869d)
+  - [NIDKG Whitepaper](https://eprint.iacr.org/2021/339.pdf)
+
+## Codebase
+
+- [Hash Tree](https://github.com/dfinity/ic/blob/master/rs/canonical_state/src/hash_tree.rs)
+- [Hash Tree Tests](https://github.com/dfinity/ic/tree/master/rs/canonical_state/src/hash_tree)
+- [Certification](https://github.com/dfinity/ic/tree/master/rs/certification)
+- [The crypto component and crypto libraries](https://github.com/dfinity/ic/tree/master/rs/crypto)
+- [Crypto interfaces (mod)](https://github.com/dfinity/ic/blob/master/rs/interfaces/src/crypto.rs)
+- [Crypto interfaces (crate)](https://github.com/dfinity/ic/tree/master/rs/interfaces/src/crypto)
+- [Crypto Protobuf definition](https://github.com/dfinity/ic/tree/master/rs/protobuf/def/crypto)
+- [Crypto Protobuf generator](https://github.com/dfinity/ic/tree/master/rs/protobuf/src/gen/crypto)
+- [Registry (NNS) crypto helper](https://github.com/dfinity/ic/blob/master/rs/registry/helpers/src/crypto.rs)
+- [Registry (NNS) crypto helper tests](https://github.com/dfinity/ic/tree/master/rs/registry/helpers/src/crypto)
+- [Crypto test utilities](https://github.com/dfinity/ic/blob/master/rs/test_utilities/src/crypto.rs)
+- [More crypto test utilities](https://github.com/dfinity/ic/tree/master/rs/test_utilities/src/crypto)
+- [Crypto tests](https://github.com/dfinity/ic/tree/master/rs/tests/crypto)
+- [Canister signature verification test](https://github.com/dfinity/ic/tree/master/rs/tests/src/canister_sig_verification_cache_test)
+- [More crypto tests](https://github.com/dfinity/ic/tree/master/rs/tests/src/crypto)
+- [Crypto types](https://github.com/dfinity/ic/blob/master/rs/types/types/src/crypto.rs)
+- [More crypto types](https://github.com/dfinity/ic/tree/master/rs/types/types/src/crypto)
+- [Validator](https://github.com/dfinity/ic/tree/master/rs/validator)

--- a/src/pages/review-primers/networking.md
+++ b/src/pages/review-primers/networking.md
@@ -22,7 +22,7 @@ layout: ../../layout/BaseLayout.astro
   - Networking adapters are used by the Bitcoin integration and HTTPS outcalls feature.
   - The main replica process uses gRPC for communicating with the co-located adapters via Unix domain sockets.
 
-### Resources
+## Resources
 
 - How it works
   - [Internet Computer Docs: Fault Tolerance](https://internetcomputer.org/how-it-works/fault-tolerance/)

--- a/src/pages/review-primers/node.md
+++ b/src/pages/review-primers/node.md
@@ -12,9 +12,10 @@ layout: ../../layout/BaseLayout.astro
 - HostOS (Host)
 - Testnet Deployment
 
-### Summary
+## Summary
 
-- IC-OS is an all-encompassing term for all the operating systems within the IC—hostOS, guestOS, SetupOS, and boundary-guestOS
+- IC-OS is an all-encompassing term for all Internet Computer operating system images including HostOS, GuestOS, SetupOS, and Boundary-GuestOS
+- Boundary-GuestOS is not relevant for replica upgrade reviews.
 - SetupOS is an image containing both the HostOS and GuestOS
     - Deploys and bootstraps HostOS
 - HostOS is the operating system that runs on the host machine
@@ -28,7 +29,7 @@ layout: ../../layout/BaseLayout.astro
   - Secure enclave is only possible in a virtual machine
   - Secure enclave is a work in progress
 
-### Resources
+## Resources
 
 - IC OS
   - [IC OS Readme](https://github.com/dfinity/ic/tree/master/ic-os#readme)
@@ -37,7 +38,7 @@ layout: ../../layout/BaseLayout.astro
   - [GuestOS Readme](https://github.com/dfinity/ic/tree/master/ic-os/guestos)
 - [Node Provider Onboarding](https://wiki.internetcomputer.org/wiki/Node_Provider_Onboarding)
 
-### Codebase
+## Codebase
 
 - [IC OS Disk Images](https://github.com/dfinity/ic/tree/master/ic-os) (except `boundary-os` and `boundary-api-os`)
 - [GuestOS Vsock Agent](https://github.com/dfinity/ic/tree/master/rs/guestos_vsock_agent)

--- a/src/pages/review-primers/overview.md
+++ b/src/pages/review-primers/overview.md
@@ -21,7 +21,7 @@ Review primers are onboarding documents that aim to arm CodeGov code reviewers w
 
 ## Resources
 
-There are already many great resources that you can use to learn about the Internet Computer overall before diving deeper into one of the lower level layers.
+There are already many great resources that you can use to learn about the Internet Computer overall before diving deeper into one of the lower-level layers.
 
 - [Internetcomputer.org](https://internetcomputer.org/)
 - [wiki.internetcomputer.org](https://wiki.internetcomputer.org/)


### PR DESCRIPTION
This PR adds the crypto review category primer.

This is another category that unfortunately doesn't have much public documentation that describes this component in detail. There is of course a lot of papers and public information about the underlying cryptographic operations that are used within the replica's crypto component, but I plan to follow up with that once I "deep dive" this review category.

I think, once I've gone through each one and established what's readily available to the public, it might be worth asking Dfinity if we can publish more information about the components of the stack that have had less exposure. The two notable ones so far are `node` and `crypto`. I've found some really great stuff internally that I think would be awesome if we could publish.