### PR TITLE
feat: use newer version of internet identity

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,9 @@
     "dfinity-foundation.vscode-motoko",
     "dbaeumer.vscode-eslint",
     "astro-build.astro-vscode",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "angular.ng-template",
+    "tamasfe.even-better-toml",
+    "rust-lang.rust-analyzer"
   ]
 }

--- a/dfx.json
+++ b/dfx.json
@@ -42,6 +42,17 @@
       },
       "source": ["src/docs/build"],
       "build": ["pnpm -F docs... build"]
+    },
+    "internet_identity": {
+      "type": "custom",
+      "candid": "https://github.com/dfinity/internet-identity/releases/download/release-2024-01-05/internet_identity.did",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2024-01-05/internet_identity_dev.wasm.gz",
+      "remote": {
+        "id": {
+          "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        }
+      },
+      "frontend": {}
     }
   }
 }

--- a/src/frontend/src/environments/environment.common.ts
+++ b/src/frontend/src/environments/environment.common.ts
@@ -7,9 +7,12 @@ export const API_GATEWAY = IS_MAINNET
 export const BACKEND_CANISTER_ID = import.meta.BACKEND_CANISTER_ID ?? '';
 export const MARKETING_CANISTER_ID = import.meta.MARKETING_CANISTER_ID ?? '';
 
+export const INTERNET_IDENTITY_CANISTER_ID =
+  import.meta.INTERNET_IDENTITY_CANISTER_ID ?? '';
+
 export const IDENTITY_PROVIDER = IS_MAINNET
-  ? 'https://identity.ic0.app/'
-  : 'http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080/';
+  ? 'https://identity.ic0.app'
+  : `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:8080`;
 
 // don't use derivation origins locally because II rejects them as invalid
 // this can be enabled locally once II supports it

--- a/src/frontend/src/typings.d.ts
+++ b/src/frontend/src/typings.d.ts
@@ -1,6 +1,7 @@
 interface ImportMeta {
   BACKEND_CANISTER_ID?: string;
   MARKETING_CANISTER_ID?: string;
+  INTERNET_IDENTITY_CANISTER_ID?: string;
   DFX_NETWORK?: string;
 }
 


### PR DESCRIPTION
The `nns` plugin for DFX automatically installs Internet Identity, but it includes a very, very old version. I've manually included a more recent version in this PR.