### PR TITLE
Proposals improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,13 @@ To list open replica version management proposals:
   - `nns_function` is a number corresponding to the NNS function to execute. The mapping between numbers and NNS functions can be found in the [`NnsFunction`](https://github.com/dfinity/ic/blob/master/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L3440-L3612) enum.
   - `payload` is the Candid encoded argument for the corresponding NNS function. The types for this argument can be found in the appropriate canister's declaration. A mapping between NNS functions and their corresponding canisters can be found in the [`NnsFunction::canister_and_function`](https://github.com/dfinity/ic/blob/master/rs/nns/governance/src/governance.rs#L527-L631) function definition.
   - For example, the `UpdateElectedReplicaVersions` uses number `38` and its payload is the [`UpdateElectedReplicaVersionsPayload`](https://github.com/dfinity/ic/blob/master/rs/registry/canister/canister/registry.did#L217-L223) record.
+
+### Manually syncing proposals
+
+To manually trigger the proposals synchronization from the Nervous Systems, run the following command:
+
+```bash
+dfx canister call backend sync_proposals
+```
+
+This method can be called at any time, since if the proposals were already synced in the cron job, they won't be synced again.

--- a/src/backend/api/backend.did
+++ b/src/backend/api/backend.did
@@ -171,6 +171,11 @@ type ListLogsResponse = variant {
   err : Err;
 };
 
+type SyncProposalsResponse = variant {
+  ok;
+  err : Err;
+};
+
 service : {
   get_my_user_profile : () -> (GetMyUserProfileResponse) query;
   get_my_user_profile_history : () -> (GetMyUserProfileHistoryResponse) query;
@@ -179,4 +184,5 @@ service : {
   update_user_profile : (UpdateUserProfileRequest) -> (UpdateUserProfileResponse);
   list_proposals : () -> (ListProposalsResponse) query;
   list_logs : (LogsFilterRequest) -> (ListLogsResponse) query;
+  sync_proposals : () -> (SyncProposalsResponse);
 };

--- a/src/backend/api/backend.did
+++ b/src/backend/api/backend.did
@@ -124,6 +124,8 @@ type Proposal = record {
   state : ReviewPeriodState;
   proposed_at : text;
   proposed_by : nat64;
+  synced_at : text;
+  review_completed_at : opt text;
 };
 
 type ProposalResponse = record {

--- a/src/backend/api/src/proposal.rs
+++ b/src/backend/api/src/proposal.rs
@@ -29,6 +29,8 @@ pub struct Proposal {
     pub state: ReviewPeriodState,
     pub proposed_at: String,
     pub proposed_by: u64,
+    pub synced_at: String,
+    pub review_completed_at: Option<String>,
 }
 
 #[derive(Debug, CandidType, Deserialize, Clone, PartialEq, Eq)]

--- a/src/backend/impl/src/controllers/init_controller.rs
+++ b/src/backend/impl/src/controllers/init_controller.rs
@@ -55,9 +55,15 @@ mod jobs {
     use ic_cdk_timers::set_timer_interval;
     use std::time::Duration;
 
+    use crate::services::{LogService, LogServiceImpl};
+
     /// Starts all cron jobs.
     pub fn start_jobs() {
         nns_proposals::start();
+
+        LogServiceImpl::default()
+            .log_info("Jobs started.".to_string(), Some("start_jobs".to_string()))
+            .unwrap();
     }
 
     mod nns_proposals {

--- a/src/backend/impl/src/controllers/proposal_controller.rs
+++ b/src/backend/impl/src/controllers/proposal_controller.rs
@@ -63,6 +63,11 @@ impl<A: AccessControlService, L: LogService, P: ProposalService> ProposalControl
     }
 
     pub async fn sync_proposals_job(&self) {
+        let _ = self.log_service.log_info(
+            "Syncing proposals".to_string(),
+            Some("sync_proposals".to_string()),
+        );
+
         match self.proposal_service.fetch_and_save_nns_proposals().await {
             Ok(_) => {
                 let _ = self.log_service.log_info(

--- a/src/backend/impl/src/fixtures/proposal.rs
+++ b/src/backend/impl/src/fixtures/proposal.rs
@@ -24,6 +24,9 @@ pub fn nns_replica_version_management_proposal() -> Proposal {
         state: ReviewPeriodState::InProgress,
         proposed_at: date_time_a(),
         proposed_by: nns_proposer(),
+        // in a real world scenario, synced_at should be after the proposed_at date
+        synced_at: date_time_a(),
+        review_completed_at: None,
     }
 }
 
@@ -38,6 +41,9 @@ pub fn nns_replica_version_management_proposal_completed() -> Proposal {
         state: ReviewPeriodState::Completed,
         proposed_at: date_time_a(),
         proposed_by: nns_proposer(),
+        // these dates don't reflect a real world scenario
+        synced_at: date_time_a(),
+        review_completed_at: Some(date_time_a()),
     }
 }
 

--- a/src/backend/impl/src/mappings/proposal.rs
+++ b/src/backend/impl/src/mappings/proposal.rs
@@ -44,6 +44,8 @@ impl From<Proposal> for backend_api::Proposal {
             state: value.state.into(),
             proposed_at: value.proposed_at.to_string(),
             proposed_by: value.proposed_by,
+            synced_at: value.synced_at.to_string(),
+            review_completed_at: value.review_completed_at.map(|dt| dt.to_string()),
         }
     }
 }

--- a/src/backend/impl/src/repositories/memories/memory_manager.rs
+++ b/src/backend/impl/src/repositories/memories/memory_manager.rs
@@ -18,3 +18,4 @@ pub(super) const USER_PROFILE_HISTORY_ID_MEMORY_ID: MemoryId = MemoryId::new(3);
 pub(super) const PROPOSALS_MEMORY_ID: MemoryId = MemoryId::new(4);
 pub(super) const LOGS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(5);
 pub(super) const LOGS_MEMORY_ID: MemoryId = MemoryId::new(6);
+pub(super) const PROPOSALS_SORTED_INDEX_MEMORY_ID: MemoryId = MemoryId::new(7);

--- a/src/backend/impl/src/repositories/memories/proposal_memory.rs
+++ b/src/backend/impl/src/repositories/memories/proposal_memory.rs
@@ -1,13 +1,22 @@
-use super::{Memory, MEMORY_MANAGER, PROPOSALS_MEMORY_ID};
-use crate::repositories::{Proposal, ProposalId};
+use super::{Memory, MEMORY_MANAGER, PROPOSALS_MEMORY_ID, PROPOSALS_SORTED_INDEX_MEMORY_ID};
+use crate::repositories::{Proposal, ProposalId, ProposalIndex};
 use ic_stable_structures::BTreeMap;
 
 pub type ProposalMemory = BTreeMap<ProposalId, Proposal, Memory>;
+pub type ProposalSortedIndexMemory = BTreeMap<ProposalIndex, (), Memory>;
 
 pub fn init_proposals() -> ProposalMemory {
     ProposalMemory::init(get_proposals_memory())
 }
 
+pub fn init_proposals_sorted_index() -> ProposalSortedIndexMemory {
+    ProposalSortedIndexMemory::init(get_proposals_sorted_index_memory())
+}
+
 fn get_proposals_memory() -> Memory {
     MEMORY_MANAGER.with(|m| m.borrow().get(PROPOSALS_MEMORY_ID))
+}
+
+fn get_proposals_sorted_index_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(PROPOSALS_SORTED_INDEX_MEMORY_ID))
 }

--- a/src/backend/impl/src/repositories/types/proposal.rs
+++ b/src/backend/impl/src/repositories/types/proposal.rs
@@ -1,3 +1,5 @@
+use crate::system_api::get_date_time;
+
 use super::{DateTime, Uuid};
 use backend_api::ApiError;
 use candid::{CandidType, Decode, Deserialize, Encode};
@@ -70,6 +72,8 @@ pub struct Proposal {
     pub state: ReviewPeriodState,
     pub proposed_at: DateTime,
     pub proposed_by: NeuronId,
+    pub synced_at: DateTime,
+    pub review_completed_at: Option<DateTime>,
 }
 
 impl Storable for Proposal {
@@ -115,12 +119,18 @@ impl TryFrom<ProposalInfo> for Proposal {
             .ok_or(ApiError::internal("Proposer is None"))?
             .id;
 
+        // the NNS proposal is casted to our proposal when it is fetched
+        // from the NNS, so here it's fine to set the synced_at time to now
+        let date_time = get_date_time()?;
+
         Ok(Proposal {
             title,
             nervous_system,
             state,
             proposed_at,
             proposed_by,
+            synced_at: DateTime::new(date_time)?,
+            review_completed_at: None,
         })
     }
 }

--- a/src/backend/impl/src/repositories/types/proposal.rs
+++ b/src/backend/impl/src/repositories/types/proposal.rs
@@ -67,12 +67,20 @@ impl From<ProposalStatus> for ReviewPeriodState {
 
 #[derive(Debug, CandidType, Deserialize, Clone, PartialEq, Eq)]
 pub struct Proposal {
+    /// The title of the proposal in the Nervous System.
     pub title: String,
+    /// The Nervous System that the proposal belongs to.
     pub nervous_system: NervousSystem,
+    /// The internal state of the proposal's review period.
     pub state: ReviewPeriodState,
+    /// The timestamp of when the proposal was proposed
+    /// in the Nervous System.
     pub proposed_at: DateTime,
+    /// The neuron id of the proposer in the Nervous System.
     pub proposed_by: NeuronId,
+    /// The timestamp of when the proposal was fetched from the Nervous System.
     pub synced_at: DateTime,
+    /// The timestamp of when the proposal's review period is completed.
     pub review_completed_at: Option<DateTime>,
 }
 

--- a/src/backend/impl/src/repositories/types/proposal.rs
+++ b/src/backend/impl/src/repositories/types/proposal.rs
@@ -6,6 +6,7 @@ use ic_stable_structures::{storable::Bound, Storable};
 use std::borrow::Cow;
 
 pub type ProposalId = Uuid;
+pub type ProposalIndex = (DateTime, ProposalId);
 pub type NervousSystemProposalId = u64;
 pub type NeuronId = u64;
 


### PR DESCRIPTION
- sorts the proposals by the `proposed_at` timestamp
- adds `synced_at` and `review_completed_at` timestamps to the proposal
- adds more logs for the cron jobs
- improves docs

The mainnet canister requires a reinstall, so that the new fields in the proposal can be filled correctly and the proposals can be sorted properly