### PR TITLE
fix: use lower voting power in nns testing script

### DIFF
--- a/src/nns-testing/src/governance/governance.ts
+++ b/src/nns-testing/src/governance/governance.ts
@@ -67,7 +67,7 @@ export class Governance {
     await this.ledger.mint(100, ownerAccount);
 
     spinner.text = 'Transferring ICP to governance account...';
-    await this.ledger.transfer(identity, 90, targetGovernanceAccount, nonce);
+    await this.ledger.transfer(identity, 10, targetGovernanceAccount, nonce);
 
     try {
       this.agent.replaceIdentity(identity);
@@ -86,7 +86,7 @@ export class Governance {
       spinner.text = 'Increasing dissolve delay...';
       await this.governanceCanister.increaseDissolveDelay({
         neuronId,
-        additionalDissolveDelaySeconds: 60 * 60 * 24 * 7 * 52 * 2, // 2 years
+        additionalDissolveDelaySeconds: 60 * 60 * 24 * 7 * 52 * 1, // 1 year
       });
 
       return neuronId;

--- a/src/nns-testing/src/index.ts
+++ b/src/nns-testing/src/index.ts
@@ -193,7 +193,10 @@ async function createRvmProposal(
 
   if (isNullish(config.neuronId)) {
     console.log('No neuron ID found, creating a neuron now...');
-    neuronId = await createNeuron(config);
+    neuronId = await createNeuron({
+      ...config,
+      identity,
+    });
   } else {
     neuronId = BigInt(config.neuronId);
   }


### PR DESCRIPTION
The previous values gave the neuron too much voting power so proposals were being immediately accepted.