### PR TITLE
fix: allow review to be set back to draft

### DIFF
--- a/src/backend/impl/src/mappings/proposal_review.rs
+++ b/src/backend/impl/src/mappings/proposal_review.rs
@@ -11,6 +11,15 @@ impl From<ProposalReviewStatus> for backend_api::ProposalReviewStatus {
     }
 }
 
+impl From<backend_api::ProposalReviewStatus> for ProposalReviewStatus {
+    fn from(proposal_review_status: backend_api::ProposalReviewStatus) -> Self {
+        match proposal_review_status {
+            backend_api::ProposalReviewStatus::Draft => ProposalReviewStatus::Draft,
+            backend_api::ProposalReviewStatus::Published => ProposalReviewStatus::Published,
+        }
+    }
+}
+
 impl From<ProposalReview> for backend_api::ProposalReview {
     fn from(proposal_review: ProposalReview) -> Self {
         backend_api::ProposalReview {


### PR DESCRIPTION
A proposal review can be set back to draft if the associated proposal is not completed