### PR TITLE
test: add users api object model

### DIFF
--- a/src/backend/integration/src/support/common.ts
+++ b/src/backend/integration/src/support/common.ts
@@ -14,36 +14,6 @@ import { Identity } from '@dfinity/agent';
 type BackendActorService = Actor<_SERVICE>;
 
 /**
- * Creates a user profile and sets the role to reviewer using the {@link controllerIdentity} identity.
- */
-export async function createReviewer(
-  actor: BackendActorService,
-  reviewer: Identity,
-): Promise<string> {
-  actor.setIdentity(reviewer);
-  const reviewerCreateRes = await actor.create_my_user_profile();
-  const reviewerCreate = extractOkResponse(reviewerCreateRes);
-
-  actor.setIdentity(controllerIdentity);
-  await actor.update_user_profile({
-    user_id: reviewerCreate.id,
-    username: ['reviewer'],
-    config: [
-      {
-        reviewer: {
-          bio: [],
-          wallet_address: [],
-          neuron_id: [],
-          social_links: [],
-        },
-      },
-    ],
-  });
-
-  return reviewerCreate.id;
-}
-
-/**
  * Creates an RVM proposal and syncs the proposals on the backend canister.
  *
  * Make sure the `title` param is unique, as it is used to find

--- a/src/backend/integration/src/support/test-driver.ts
+++ b/src/backend/integration/src/support/test-driver.ts
@@ -8,6 +8,7 @@ import {
 } from '@hadronous/pic';
 import { resolve } from 'node:path';
 import { controllerIdentity } from './identity';
+import { UsersOM } from './users';
 
 const NNS_SUBNET_ID =
   '2o3zy-oo4hc-r3mtq-ylrpf-g6qge-qmuzn-2bsuv-d3yhd-e4qjc-6ff2b-6ae';
@@ -47,10 +48,14 @@ export class TestDriver {
     return this.fixture.canisterId;
   }
 
+  public readonly users: UsersOM;
+
   private constructor(
     public readonly pic: PocketIc,
     private readonly fixture: CanisterFixture<BackendService>,
-  ) {}
+  ) {
+    this.users = new UsersOM(this.createActor());
+  }
 
   public static async create(initialDate = new Date()): Promise<TestDriver> {
     const pic = await PocketIc.create(process.env.PIC_URL);
@@ -110,5 +115,9 @@ export class TestDriver {
 
   public async tearDown(): Promise<void> {
     await this.pic.tearDown();
+  }
+
+  private createActor(): Actor<BackendService> {
+    return this.pic.createActor(idlFactory, this.canisterId);
   }
 }

--- a/src/backend/integration/src/support/users.ts
+++ b/src/backend/integration/src/support/users.ts
@@ -1,0 +1,81 @@
+import { Actor, generateRandomIdentity } from '@hadronous/pic';
+import {
+  _SERVICE as BackendService,
+  CreateMyUserProfileResponse,
+  UserConfigUpdate,
+} from '@cg/backend';
+import { OkResponse, extractOkResponse } from './response';
+import { controllerIdentity } from './identity';
+import { Identity } from '@dfinity/agent';
+import { optional } from '@cg/nns-utils';
+
+export class UsersOM {
+  constructor(private readonly actor: Actor<BackendService>) {}
+
+  /**
+   * Creates a user profile and sets the role to reviewer using the {@link controllerIdentity} identity.
+   */
+  public async createReviewer(): Promise<
+    [Identity, OkResponse<CreateMyUserProfileResponse>]
+  > {
+    const [identity, userProfile] = await this.createUser();
+    await this.updateUser(userProfile.id, 'reviewer', {
+      reviewer: {
+        bio: [],
+        wallet_address: [],
+        neuron_id: [],
+        social_links: [],
+      },
+    });
+
+    return [identity, userProfile];
+  }
+
+  public async createAdmin(): Promise<
+    [Identity, OkResponse<CreateMyUserProfileResponse>]
+  > {
+    const [identity, userProfile] = await this.createUser();
+    await this.updateUser(userProfile.id, 'admin', {
+      admin: {
+        bio: [],
+      },
+    });
+
+    return [identity, userProfile];
+  }
+
+  public async createAnonymous(): Promise<
+    [Identity, OkResponse<CreateMyUserProfileResponse>]
+  > {
+    const [identity, userProfile] = await this.createUser();
+    await this.updateUser(userProfile.id, 'anonymous');
+
+    return [identity, userProfile];
+  }
+
+  private async createUser(): Promise<
+    [Identity, OkResponse<CreateMyUserProfileResponse>]
+  > {
+    const identity = generateRandomIdentity();
+
+    this.actor.setIdentity(identity);
+    const createRes = await this.actor.create_my_user_profile();
+    const createOkRes = extractOkResponse(createRes);
+
+    return [identity, createOkRes];
+  }
+
+  private async updateUser(
+    id: string,
+    username: string,
+    update?: UserConfigUpdate,
+  ): Promise<void> {
+    this.actor.setIdentity(controllerIdentity);
+    const updateRes = await this.actor.update_user_profile({
+      user_id: id,
+      username: optional(username),
+      config: optional(update),
+    });
+    extractOkResponse(updateRes);
+  }
+}

--- a/src/backend/integration/src/tests/get_proposal_review.spec.ts
+++ b/src/backend/integration/src/tests/get_proposal_review.spec.ts
@@ -1,6 +1,5 @@
 import { describe, beforeAll, afterAll, it, expect } from 'bun:test';
 import { AnonymousIdentity, Identity } from '@dfinity/agent';
-import { generateRandomIdentity } from '@hadronous/pic';
 import {
   Governance,
   TestDriver,
@@ -10,7 +9,6 @@ import {
   controllerIdentity,
   createProposalReview,
   createProposalReviewCommit,
-  createReviewer,
   extractErrResponse,
   extractOkResponse,
   publishProposalReview,
@@ -41,8 +39,7 @@ describe('get proposal review', () => {
   });
 
   beforeAll(async () => {
-    alice = generateRandomIdentity();
-    aliceId = await createReviewer(driver.actor, alice);
+    [alice, { id: aliceId }] = await driver.users.createReviewer();
 
     proposalReviewData = await createProposalReview(
       driver.actor,
@@ -101,8 +98,7 @@ describe('get proposal review', () => {
   });
 
   it('should fail for a draft review if the user is not an admin or the owner', async () => {
-    const bob = generateRandomIdentity();
-    await createReviewer(driver.actor, bob);
+    const [bob] = await driver.users.createReviewer();
 
     driver.actor.setIdentity(bob);
     const resBob = await driver.actor.get_proposal_review({

--- a/src/backend/integration/src/tests/list_proposal_reviews.spec.ts
+++ b/src/backend/integration/src/tests/list_proposal_reviews.spec.ts
@@ -1,5 +1,4 @@
 import { AnonymousIdentity, Identity } from '@dfinity/agent';
-import { generateRandomIdentity } from '@hadronous/pic';
 import { describe, beforeAll, afterAll, it, expect } from 'bun:test';
 import {
   Governance,
@@ -10,7 +9,6 @@ import {
   createProposal,
   createProposalReview,
   createProposalReviewCommit,
-  createReviewer,
   extractErrResponse,
   extractOkResponse,
   publishProposalReview,
@@ -64,11 +62,8 @@ describe('list proposal reviews', () => {
      *     commits: [VALID_COMMIT_SHA_A, VALID_COMMIT_SHA_B]
      */
 
-    alice = generateRandomIdentity();
-    bob = generateRandomIdentity();
-
-    aliceId = await createReviewer(driver.actor, alice);
-    bobId = await createReviewer(driver.actor, bob);
+    [alice, { id: aliceId }] = await driver.users.createReviewer();
+    [bob, { id: bobId }] = await driver.users.createReviewer();
 
     proposal1Id = await createProposal(
       driver.actor,

--- a/src/backend/integration/src/tests/proposal_review.spec.ts
+++ b/src/backend/integration/src/tests/proposal_review.spec.ts
@@ -7,7 +7,6 @@ import {
   expect,
 } from 'bun:test';
 import type { ProposalReview } from '@cg/backend';
-import { generateRandomIdentity } from '@hadronous/pic';
 import {
   anonymousIdentity,
   controllerIdentity,
@@ -18,7 +17,6 @@ import {
   createProposal,
   completeProposal,
   createProposalReview,
-  createReviewer,
   TestDriver,
 } from '../support';
 
@@ -62,10 +60,8 @@ describe('Proposal Review', () => {
 
     it('should not allow non-reviewer principals', async () => {
       // as anonymous user
-      const alice = generateRandomIdentity();
+      const [alice] = await driver.users.createAnonymous();
       driver.actor.setIdentity(alice);
-
-      await driver.actor.create_my_user_profile();
 
       const resAnonymous = await driver.actor.create_proposal_review({
         proposal_id: 'proposal-id',
@@ -104,8 +100,8 @@ describe('Proposal Review', () => {
     });
 
     it('should allow reviewers to create a proposal review', async () => {
-      const reviewer = generateRandomIdentity();
-      const reviewerId = await createReviewer(driver.actor, reviewer);
+      const [reviewer, { id: reviewerId }] =
+        await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,
@@ -143,8 +139,8 @@ describe('Proposal Review', () => {
     });
 
     it('should allow reviewers to create an empty proposal review', async () => {
-      const reviewer = generateRandomIdentity();
-      const reviewerId = await createReviewer(driver.actor, reviewer);
+      const [reviewer, { id: reviewerId }] =
+        await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,
@@ -182,8 +178,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to create a review for a proposal that does not exist', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const nonExistentProposalId = 'c61d2984-16c6-4918-9e8b-ed8ee1b05680';
 
@@ -204,8 +199,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to create a review for a proposal that is completed', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,
@@ -231,8 +225,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to create multiple reviews for the same reviewer and proposal', async () => {
-      const alice = generateRandomIdentity();
-      const aliceId = await createReviewer(driver.actor, alice);
+      const [alice, { id: aliceId }] = await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,
@@ -264,8 +257,7 @@ describe('Proposal Review', () => {
         message: `User with Id ${aliceId} has already submitted a review for proposal with Id ${proposalId}`,
       });
 
-      const bob = generateRandomIdentity();
-      await createReviewer(driver.actor, bob);
+      const [bob] = await driver.users.createReviewer();
       driver.actor.setIdentity(bob);
       const resBobCreated = await driver.actor.create_proposal_review({
         proposal_id: proposalId,
@@ -278,8 +270,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to create an invalid review', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,
@@ -371,10 +362,8 @@ describe('Proposal Review', () => {
 
     it('should not allow non-reviewer principals', async () => {
       // as anonymous user
-      const alice = generateRandomIdentity();
+      const [alice] = await driver.users.createAnonymous();
       driver.actor.setIdentity(alice);
-
-      await driver.actor.create_my_user_profile();
 
       const resAnonymous = await driver.actor.update_proposal_review({
         proposal_id: 'proposal-id',
@@ -415,8 +404,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to update a proposal review that does not exist', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const nonExistentProposalId = 'c61d2984-16c6-4918-9e8b-ed8ee1b05680';
 
@@ -439,10 +427,8 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow a reviewer to update a proposal review that belongs to another reviewer', async () => {
-      const alice = generateRandomIdentity();
-      const bob = generateRandomIdentity();
-      await createReviewer(driver.actor, alice);
-      await createReviewer(driver.actor, bob);
+      const [alice] = await driver.users.createReviewer();
+      const [bob] = await driver.users.createReviewer();
 
       const { proposalId } = await createProposalReview(
         driver.actor,
@@ -469,8 +455,7 @@ describe('Proposal Review', () => {
     });
 
     it('should allow a reviewer to update a proposal review', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const { proposalId } = await createProposalReview(
         driver.actor,
@@ -494,8 +479,7 @@ describe('Proposal Review', () => {
     });
 
     it('should allow a reviewer to publish a proposal review', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const { proposalId } = await createProposalReview(
         driver.actor,
@@ -519,8 +503,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow a reviewer to update a proposal review for a completed proposal', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,
@@ -558,8 +541,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow a reviewer to update a proposal review that is already published', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const { proposalId } = await createProposalReview(
         driver.actor,
@@ -611,8 +593,7 @@ describe('Proposal Review', () => {
     });
 
     it('should allow a reviewer to set a published proposal review back to draft', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const { proposalId } = await createProposalReview(
         driver.actor,
@@ -646,8 +627,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to update a review with invalid fields', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const { proposalId } = await createProposalReview(
         driver.actor,
@@ -719,8 +699,7 @@ describe('Proposal Review', () => {
     });
 
     it('should not allow to publish a review that has invalid fields', async () => {
-      const reviewer = generateRandomIdentity();
-      await createReviewer(driver.actor, reviewer);
+      const [reviewer] = await driver.users.createReviewer();
 
       const proposalId = await createProposal(
         driver.actor,

--- a/src/frontend/src/.ic-assets.json
+++ b/src/frontend/src/.ic-assets.json
@@ -2,7 +2,7 @@
   {
     "match": "**/*",
     "headers": {
-      "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'wasm-unsafe-eval'; connect-src 'self' https://icp-api.io; img-src 'self' data:; style-src * 'unsafe-inline'; style-src-elem * 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests;",
+      "Content-Security-Policy": "default-src 'self'; connect-src 'self' https://icp-api.io; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content",
       "Permissions-Policy": "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(), speaker-selection=(), conversion-measurement=(), focus-without-user-activation=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), sync-script=(), trust-token-redemption=(), window-placement=(), vertical-scroll=()",
       "X-Frame-Options": "DENY",
       "Referrer-Policy": "same-origin",


### PR DESCRIPTION
This is an attempt to make a structured approach to sharing common code, like creating users or proposals. I've put user creation code into an "Object model" ([inspiration](https://medium.com/@khaled_arfaoui/api-object-model-a-functional-approach-to-test-your-apis-f982bad60f9f#:~:text=Unveiling%20API%20Object%20Models,%2C%20within%20well%2Dstructured%20objects.)]. 

I'll split the proposals and proposal reviews into separate object models too, if we agree with this approach. All object models will be accessible through the driver and they'll have their own actors setup so it should feel nice and ergonomic to use.